### PR TITLE
Windows does not throw FileNotFoundException

### DIFF
--- a/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/GenericFileRenameExclusiveReadLockStrategy.java
+++ b/components/camel-file/src/main/java/org/apache/camel/component/file/strategy/GenericFileRenameExclusiveReadLockStrategy.java
@@ -17,6 +17,7 @@
 package org.apache.camel.component.file.strategy;
 
 import java.io.FileNotFoundException;
+import java.nio.file.FileSystemException;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.LoggingLevel;
@@ -79,7 +80,7 @@ public class GenericFileRenameExclusiveReadLockStrategy<T> implements GenericFil
             try {
                 exclusive = operations.renameFile(file.getAbsoluteFilePath(), newFile.getAbsoluteFilePath());
             } catch (GenericFileOperationFailedException ex) {
-                if (ex.getCause() instanceof FileNotFoundException) {
+                if (ex.getCause() instanceof FileNotFoundException || ex.getCause() instanceof FileSystemException) {
                     exclusive = false;
                 } else {
                     throw ex;


### PR DESCRIPTION
Windows Environment throws FileSystemException when the file is blocked by another process

<!-- Uncomment and fill this section if your PR is not trivial
- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/CAMEL) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
- [ ] Each commit in the pull request should have a meaningful subject line and body.
- [ ] If you're unsure, you can format the pull request title like `[CAMEL-XXX] Fixes bug in camel-file component`, where you replace `CAMEL-XXX` with the appropriate JIRA issue.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Run `mvn clean install -Psourcecheck` in your module with source check enabled to make sure basic checks pass and there are no checkstyle violations. A more thorough check will be performed on your pull request automatically.
Below are the contribution guidelines:
https://github.com/apache/camel/blob/main/CONTRIBUTING.md
-->

Exception thrown in Windows when a file is blocked by another process:

```
2022-09-09 09:14:54,555 WARN  [org.apa.cam.com.fil.FileConsumer] (Camel (camel-1) thread #1 - file://c:%5Ctemp%5Cinput) file://c:%5Ctemp%5Cinput?delay=500&move=c%3A%5Ctemp%5Csave%2F%24%7Bfile%3Aname%7D&moveFailed=c%3A%5Ctemp%5Cerror%2F%24%7Bfile%3Aname%7D cannot begin processing file: GenericFile[c:\temp\input\test.txt] due to: Error renaming file from c:\temp\input\test.txt to c:\temp\input\test.txt.camelExclusiveReadLock. Caused by: [org.apache.camel.component.file.GenericFileOperationFailedException - Error renaming file from c:\temp\input\test.txt to c:\temp\input\test.txt.camelExclusiveReadLock]: org.apache.camel.component.file.GenericFileOperationFailedException: Error renaming file from c:\temp\input\test.txt to c:\temp\input\test.txt.camelExclusiveReadLock
	at org.apache.camel.component.file.FileOperations.renameFile(FileOperations.java:93)
	at org.apache.camel.component.file.strategy.GenericFileRenameExclusiveReadLockStrategy.acquireExclusiveReadLock(GenericFileRenameExclusiveReadLockStrategy.java:80)
	at org.apache.camel.component.file.strategy.FileRenameExclusiveReadLockStrategy.acquireExclusiveReadLock(FileRenameExclusiveReadLockStrategy.java:49)
	at org.apache.camel.component.file.strategy.GenericFileProcessStrategySupport.begin(GenericFileProcessStrategySupport.java:72)
	at org.apache.camel.component.file.strategy.GenericFileRenameProcessStrategy.begin(GenericFileRenameProcessStrategy.java:39)
	at org.apache.camel.component.file.GenericFileConsumer.processExchange(GenericFileConsumer.java:388)
	at org.apache.camel.component.file.GenericFileConsumer.processBatch(GenericFileConsumer.java:245)
	at org.apache.camel.component.file.GenericFileConsumer.poll(GenericFileConsumer.java:206)
	at org.apache.camel.support.ScheduledPollConsumer.doRun(ScheduledPollConsumer.java:202)
	at org.apache.camel.support.ScheduledPollConsumer.run(ScheduledPollConsumer.java:116)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.nio.file.FileSystemException: c:\temp\input\test.txt -> c:\temp\input\test.txt.camelExclusiveReadLock: The process cannot access the file because it is being used by another process.

	at java.base/sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:92)
	at java.base/sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:103)
	at java.base/sun.nio.fs.WindowsFileCopy.copy(WindowsFileCopy.java:202)
	at java.base/sun.nio.fs.WindowsFileSystemProvider.copy(WindowsFileSystemProvider.java:283)
	at java.base/java.nio.file.Files.copy(Files.java:1295)
	at org.apache.camel.util.FileUtil.copyFile(FileUtil.java:480)
	at org.apache.camel.util.FileUtil.renameFileUsingCopy(FileUtil.java:462)
	at org.apache.camel.util.FileUtil.renameFile(FileUtil.java:436)
	at org.apache.camel.component.file.FileOperations.renameFile(FileOperations.java:90)
	... 15 more
```